### PR TITLE
Fix wrong key for making a post a draft in post documentation

### DIFF
--- a/resources/templates/md/docs/writing-posts.md
+++ b/resources/templates/md/docs/writing-posts.md
@@ -80,7 +80,7 @@ Set this to true if you want a table of contents to be generated from the header
 </td>
 </tr>
 <tr>
-<td>`draft`</td>
+<td>`draft?`</td>
 <td>
 Files that have this key set to `true` will not be included in the compilation process.
 </td>


### PR DESCRIPTION
This confused me for a couple minutes when I was trying to mark a post as a draft.

Thought this might help the next person who runs into this.

In c.compiler on Line 125:
(remove #(= (:draft? %) true))))

Thanks!
