### PR TITLE
Update docs to flatter structure

### DIFF
--- a/resources/templates/md/docs/configuration.md
+++ b/resources/templates/md/docs/configuration.md
@@ -6,7 +6,7 @@
 
 ## Your Options
 
-Cryogen provides some flexible configuration options. Your site's configuration file can be found at `templates/config.edn` and contains the following by default:
+Cryogen provides some flexible configuration options. Your site's configuration file can be found at `content/config.edn` and contains the following by default:
 
 ```clojure
 {:site-title           "My Awesome Blog"
@@ -84,7 +84,7 @@ Keys marked with a * must be provided.
 </tr>
 <tr>
 <td>`post-root-uri`</td>
-<td>The folder where the compiler will output compiled blog posts. This value is prepended to all post uri's. If this key is omitted then the name of the output folder will be the same as the `post-root` folder. If the an string ("") is provided then the posts will be outputted to the root folder of the blog (ie. `resources/public/{blog-prefix}`).
+<td>The folder where the compiler will output compiled blog posts. This value is prepended to all post uri's. If this key is omitted then the name of the output folder will be the same as the `post-root` folder. If the an string ("") is provided then the posts will be outputted to the root folder of the blog (ie. `public/{blog-prefix}`).
 </td>
 </tr>
 <tr>
@@ -149,7 +149,7 @@ search path or has a different name than please adapt this value.
 </tr>
 <tr>
 <td>* `resources`</td>
-<td>A vector of directories/files to be copied over from `templates` to `public` upon compilation.</td>
+<td>A vector of directories/files to be copied over from `content` to `public` upon compilation.</td>
 </tr>
 <tr>
 <td>* `keep-files`</td>
@@ -200,6 +200,10 @@ See [Klipse Integration](klipse.html) for details.</td>
 <td>* `debug?`</td>
 <td>Enable debug outputs for compiler.</td>
 </tr>
+<tr>
+<td>`public-dest`</td>
+<td>Sets where to output the rendered site. Defaults to `"public"` if not specified.
+</tr>
 </tbody>
 </table>
 
@@ -232,8 +236,8 @@ In addition to these default configuration options, you may add your own custom 
  (defn init []
   (load-plugins)
   (compile-assets-timed (read-string (slurp "secrets.edn")))
-  (let [ignored-files (-> (read-config) :ignored-files)]
-    (start-watcher! "resources/templates" ignored-files (partial compile-assets-timed
+  (let [ignored-files (-> (resolve-config) :ignored-files)]
+    (start-watcher! "content" ignored-files (partial compile-assets-timed
                                                                  (read-string (slurp "secrets.edn"))))))
 ;; ...
 ```

--- a/resources/templates/md/docs/deploying-to-github-pages.md
+++ b/resources/templates/md/docs/deploying-to-github-pages.md
@@ -65,7 +65,7 @@ If you make any changes to your site, simply follow this deployment step to upda
 
 If you'd like to use a custom domain, GitHub supports this by configuring a `CNAME` file in the root of your repository. You'll need to acquire a domain from a registrar and then setup either a `CNAME` record or an `A` record pointing to GitHub. GitHub has documentation [here](https://help.github.com/articles/quick-start-setting-up-a-custom-domain/) that details the difference.
 
-For the Cryogen part, create a file called `CNAME` at `resources/templates/CNAME` with contents similar to this:
+For the Cryogen part, create a file called `CNAME` at `content/CNAME` with contents similar to this:
 
 ```
 cryogenweb.org
@@ -77,4 +77,4 @@ Now edit your `config.edn` and add `CNAME` to your `:resources`:
 :resources ["img" "CNAME"]
 ```
 
-Now when you build, your CNAME file should be copied into your `resources/public/` folder.
+Now when you build, your CNAME file should be copied into your `public/` folder.

--- a/resources/templates/md/docs/structure.md
+++ b/resources/templates/md/docs/structure.md
@@ -8,48 +8,47 @@ A basic Cryogen site usually looks something like this:
 
 ```
 my-blog
-├── resources
-│   ├── public
-│   │   ⋮
-│   └── templates
-│       ├── asc
-│       │   ├── pages
-│       │   │   └── adoc-page.asc
-│       │   └── posts
-│       │       └── 2014-10-10-adoc-post.asc
-│       ├── md
-│       │   ├── pages
-│       │   │   ├── about.md
-│       │   │   └── another-page.md
-│       │   └── posts
-│       │       ├── 2014-03-10-first-post.md
-│       │       ├── 2014-11-04-second-post.md
-│       │       └── 2014-12-11-docs.md
-│       ├── img
-│       ├── themes
-│       │   ├── blue
-│       │   │   ├── css
-│       │   │   │   └── screen.css
-│       │   │   ├── html
-│       │   │   │   ├── 404.html
-│       │   │   │   ├── archives.html
-│       │   │   │   ├── base.html
-│       │   │   │   ├── home.html
-│       │   │   │   ├── page.html
-│       │   │   │   ├── post-content.html
-│       │   │   │   ├── post.html
-│       │   │   │   ├── previews.html
-│       │   │   │   ├── tag.html
-│       │   │   │   └── tags.html
-│       │   │   └── js
-│       │   │       └── highlight.pack.js
-│       │   └── blue_centered
-│       │       ⋮
-│       ├── config.edn
+├── content
+│   ├── asc
+│   │   ├── pages
+│   │   │   └── adoc-page.asc
+│   │   └── posts
+│   │       └── 2014-10-10-adoc-post.asc
+│   ├── md
+│   │   ├── pages
+│   │   │   ├── about.md
+│   │   │   └── another-page.md
+│   │   └── posts
+│   │       ├── 2014-03-10-first-post.md
+│   │       ├── 2014-11-04-second-post.md
+│   │       └── 2014-12-11-docs.md
+│   ├── img
+│   └── config.edn
+├── public
+│   ⋮
 ├── src
 │   └── cryogen
 │       ├── core.clj
-│       └── server.clj       
+│       └── server.clj
+├── themes
+│   ├── blue
+│   │   ├── css
+│   │   │   └── screen.css
+│   │   ├── html
+│   │   │   ├── 404.html
+│   │   │   ├── archives.html
+│   │   │   ├── base.html
+│   │   │   ├── home.html
+│   │   │   ├── page.html
+│   │   │   ├── post-content.html
+│   │   │   ├── post.html
+│   │   │   ├── previews.html
+│   │   │   ├── tag.html
+│   │   │   └── tags.html
+│   │   └── js
+│   │       └── highlight.pack.js
+│   └── blue_centered
+│       ⋮
 └── project.clj
 ```
 
@@ -62,16 +61,12 @@ my-blog
 </thead>
 <tbody>
 <tr>
-<td>`resources`</td>
-<td>This is where all of your site content and configuration will go. It's divided into the `templates` folder and the `public` folder.</td>
-</tr>
-<tr>
 <td>`public`</td>
 <td>This is where the generated site will go once Cryogen is done compiling your content.</td>
 </tr>
 <tr>
-<td>`templates`</td>
-<td>The main folder where all your HTML themes and Markdown/AsciiDoc content will go.</td>
+<td>`content`</td>
+<td>The main folder where all your Markdown/AsciiDoc content and other resources will go.</td>
 </tr>
 <tr>
 <td>`asc`</td>

--- a/resources/templates/md/docs/switching-markdown-asciidoc.md
+++ b/resources/templates/md/docs/switching-markdown-asciidoc.md
@@ -6,4 +6,4 @@
  Cryogen comes with [Markdown](https://daringfireball.net/projects/markdown/) support by default and you can only use one or the other.
 
  If you want to use [AsciiDoc](http://asciidoctor.org/docs/what-is-asciidoc/) instead of Markdown, open the `project.clj` in your created blog and change the line in `:dependencies` that says `cryogen-markdown` to `cryogen-asciidoc`.
- Instead of looking for files ending in `.md` in the `templates/md` directory, the compiler will now look for files ending in `.asc` in the `templates/asc` directory.
+ Instead of looking for files ending in `.md` in the `content/md` directory, the compiler will now look for files ending in `.asc` in the `content/asc` directory.

--- a/resources/templates/md/docs/writing-posts.md
+++ b/resources/templates/md/docs/writing-posts.md
@@ -12,7 +12,7 @@ All of your blog posts should reside under the `post-root` folder specified in y
 
 ## Creating Posts
 
-To create a new blog post, all you need to do is create a new Markdown or AsciiDoc file (depending on what you're using - you can only choose one) under your `post-root` directory. If you are using Markdown then the files should reside under `templages/md/{post-root}`. If you are using AsciiDoc then the files should reside under `templages/asc/{post-root}`. You must add a date to your post in one of two ways.
+To create a new blog post, all you need to do is create a new Markdown or AsciiDoc file (depending on what you're using - you can only choose one) under your `post-root` directory. If you are using Markdown then the files should reside under `content/md/{post-root}`. If you are using AsciiDoc then the files should reside under `content/asc/{post-root}`. You must add a date to your post in one of two ways.
 
 The first option is to specify the date of the post right in the name of the Markdown file. The way you name these files is important. The date format in your file name must match the date format specified in your `config.edn` file.
 
@@ -117,7 +117,7 @@ The rest of your file should contain valid Markdown content. For example:
 
 ### Multiple Authors
 
-You can specify the author for a particular post by including the `:author` key in the post metadata as shown above. If you happen to have multiple authors writing on your blog and want to generate a page with posts filtered by author you should provide the `:author-root-uri` value in the `config.edn` file. The compiler will use the `templates/themes/{theme}/html/author.html` layout and will generate a page with the same name as the author. For post without author the global `:author` value from `config.edn` will be used.
+You can specify the author for a particular post by including the `:author` key in the post metadata as shown above. If you happen to have multiple authors writing on your blog and want to generate a page with posts filtered by author you should provide the `:author-root-uri` value in the `config.edn` file. The compiler will use the `themes/{theme}/html/author.html` layout and will generate a page with the same name as the author. For post without author the global `:author` value from `config.edn` will be used.
 
 ### Tags
 
@@ -127,7 +127,7 @@ Cryogen will automatically create a page for each unique tag that you've used in
 
 You'll probably want to include images in your pages or posts eventually. There are different places where you can store these images.
 
-The common option is to keep them in one folder under the `templates` directory such as `assets` or `img`. Make sure to include the name of this folder in the `resources` key in your config so the images get transfered to the `public` folder when your site compiles.
+The common option is to keep them in one folder under the `content` directory such as `assets` or `img`. Make sure to include the name of this folder in the `resources` key in your config so the images get transfered to the `public` folder when your site compiles.
 
 The other option is to keep them alongside your Markdown files. This means you would have to save your posts that contain images in a separate folder under your `post-root`. For example:
 
@@ -145,7 +145,7 @@ If you'd like to organize your posts in this fashion, please keep in mind that t
 
 ### Images and Markdown
 
-All images should be included in your Markdown content in the following format. (If `img` were a folder that you created under `resources/templates`.)
+All images should be included in your Markdown content in the following format. (If `img` were a folder that you created under `content`.)
 
 ```
 ![Image 1](/img/img01.png)
@@ -173,4 +173,4 @@ If you wish to enable comments on your posts, create a [disqus](https://disqus.c
 
 ## Post Archives
 
-Cryogen will automatically generate and update a post archives page for you. If you'd like to change the layout of this page, you can do so by editing the HTML in `templates/themes/{theme}/html/archives.html`.
+Cryogen will automatically generate and update a post archives page for you. If you'd like to change the layout of this page, you can do so by editing the HTML in `themes/{theme}/html/archives.html`.


### PR DESCRIPTION
Update docs to match the new structure project from https://github.com/cryogen-project/cryogen-core/pull/117

I haven't update the structure of this yet, I think that might make more sense as a future PR if you want this repo to use the latest version of Cryogen?

Thanks!