### PR TITLE
Allow multiple extensions in AsciiDoc Markup.

### DIFF
--- a/resources/templates/md/docs/switching-markdown-asciidoc.md
+++ b/resources/templates/md/docs/switching-markdown-asciidoc.md
@@ -6,4 +6,4 @@
  Cryogen comes with [Markdown](https://daringfireball.net/projects/markdown/) support by default and you can only use one or the other.
 
  If you want to use [AsciiDoc](http://asciidoctor.org/docs/what-is-asciidoc/) instead of Markdown, open the `project.clj` in your created blog and change the line in `:dependencies` that says `cryogen-flexmark` to `cryogen-asciidoc`.
- Instead of looking for files ending in `.md` in the `content/md` directory, the compiler will now look for files ending in `.asc` in the `content/asc` directory.
+ Instead of looking for files ending in `.md` in the `content/md` directory, the compiler will now look for files ending in any of the following extensions in the `content/asc` directory: `.adoc`, `.ad`, `.asciidoc`, `.asc`.


### PR DESCRIPTION
Addresses Issue number 6 in the `cryogen-asciidoc` repo.
For the set of related PRs see the main PR on the `cryogen-core` repo.