### PR TITLE
Document Clj CLI usage, use serve

### DIFF
--- a/content/md/docs/configuration.md
+++ b/content/md/docs/configuration.md
@@ -194,7 +194,8 @@ search path or has a different name than please adapt this value.
 </tr>
 <tr>
 	<td>* `clean-urls`</td>
-	<td>`:trailing-slash`, `:no-trailing-slash`, and `:dirty` are valid options. Set this to `:trailing-slash` to emit html as subdirectories, e.g., `prefix/root/page-name/index.html`. Links would then end in `/page-name/`. Set this to `:no-trailing-slash` if you use GitHub Pages and prefer URLs not contain a final trailing slash. Links would then end in `/page-name`. <strong>Note:</strong> `:no-trailing-slash` will not work on all hosting providers such as Amazon S3. Set this to `:dirty` will result in `prefix/root/page-name.html`. Links would then end in `/page-name.html`</td>
+	<td>`:trailing-slash`, `:no-trailing-slash`, and `:dirty` are valid options. Set this to `:trailing-slash` to emit html as subdirectories, e.g., `prefix/root/page-name/index.html`. Links would then end in `/page-name/`. Set this to `:no-trailing-slash` if you use GitHub Pages and prefer URLs not contain a final trailing slash. Links would then end in `/page-name`. <strong>Note:</strong> `:no-trailing-slash` will not work on all hosting providers such as Amazon S3. Set this to `:dirty` will result in `prefix/root/page-name.html`. Links would then end in `/page-name.html`
+	<strong>Note 2:</strong> You can override the default URL with a smart use of <a href="/docs/customizing-cryogen.html"><code>:update-article-fn</code></a>.</td>
 </tr>
 <tr>
 	<td>`collapse-subdirs?`</td>
@@ -252,7 +253,7 @@ In addition to these default configuration options, you may add your own custom 
        (start-watcher! "themes" ignored-files (partial compile-assets-timed overrides)))))
 ;; ...
 ```
-### Deriving Params
+### Deriving Additional Params for Use in Templates
 
 If you wish to further derive more parameters from the data that the cryogen compiler generates, you may pass in a `:extend-params-fn` in your overrides map which will be invoked by the compiler like so
 
@@ -266,3 +267,6 @@ If you wish to further derive more parameters from the data that the cryogen com
    :sidebar-pages sidebar-pages})
 ```
 
+It should return the `params`, likely with additional keys. These will be visible to your templates.
+
+See [Customizing/Extending Cryogen](/docs/customizing-cryogen.html) for an example.

--- a/content/md/docs/getting-started.md
+++ b/content/md/docs/getting-started.md
@@ -5,12 +5,18 @@
 
 Cryogen aims to be as simple as possible. There's no need to set up a database or jump through hoops just to get a boilerplate template going.
 
-To get started, you'll need to have [Leiningen](http://leiningen.org/) installed. Once you have that ready, here's how to get the base template.
+To get started, you'll need to have either [Leiningen](http://leiningen.org/) or [Clojure CLI](https://clojure.org/guides/deps_and_cli) with [clj-new](https://github.com/seancorfield/clj-new/). Once you have that ready, here's how to get the base template.
 
 ```
+# Leiningen:
 ~ $ lein new cryogen my-blog
 ~ $ cd my-blog
-~/my-blog $ lein ring server
+~/my-blog $ lein serve
+
+# Clojure CLI:
+~ $ clojure -X:new create :template cryogen :name me.my-blog
+~ $ cd me.my-blog
+~/my-blog $ clojure -X:serve
 ```
 
 Once the server starts, you can visit your site at `localhost:3000`. The first thing you'll see is a helpful README on what to do next.

--- a/project.clj
+++ b/project.clj
@@ -15,4 +15,6 @@
             :plugins [[lein-ring "0.12.5"]]
             :main cryogen.core
             :ring {:init cryogen.server/init
-                   :handler cryogen.server/handler})
+                   :handler cryogen.server/handler}
+            :aliases {"serve"      ["run" "-m" "cryogen.server"]
+                      "serve-fast" ["run" "-m" "cryogen.server" "fast"]})

--- a/src/cryogen/server.clj
+++ b/src/cryogen/server.clj
@@ -5,18 +5,22 @@
    [compojure.route :as route]
    [ring.util.response :refer [redirect file-response]]
    [ring.util.codec :refer [url-decode]]
-   [cryogen-core.watcher :refer [start-watcher!]]
+   [ring.server.standalone :as ring-server]
+   [cryogen-core.watcher :refer [start-watcher! #_start-watcher-for-changes!]]
    [cryogen-core.plugins :refer [load-plugins]]
    [cryogen.compiler :refer [compile-assets-timed]]
    [cryogen-core.config :refer [resolve-config]]
    [cryogen-core.io :refer [path]]))
 
-(defn init []
+(defn init [fast?]
   (load-plugins)
   (compile-assets-timed)
   (let [ignored-files (-> (resolve-config) :ignored-files)]
-    (start-watcher! "content" ignored-files compile-assets-timed)
-    (start-watcher! "themes" ignored-files compile-assets-timed)))
+    (run!
+      #(if true #_fast?
+         #_(start-watcher-for-changes! % ignored-files compile-assets-timed {})
+         (start-watcher! % ignored-files compile-assets-timed))
+      ["content" "themes"])))
 
 (defn wrap-subdirectories
   [handler]
@@ -53,3 +57,13 @@
   (route/not-found "Page not found"))
 
 (def handler (wrap-subdirectories routes))
+
+(defn serve
+  "Entrypoint for running via tools-deps (`clojure -X:serve`)"
+  [{:keys [fast] :as opts}]
+  (ring-server/serve
+    handler
+    (merge {:init (partial init fast)} opts)))
+
+(defn -main [& args]
+  (serve {:port 3000, :fast ((set args) "fast")}))

--- a/themes/docs/css/screen.css
+++ b/themes/docs/css/screen.css
@@ -111,6 +111,10 @@ header h2#slogan {
     color: #e1e100;
 }
 
+.shell code .comment .hljs-comment {
+    color: #aca9a9;
+}
+
 #reading-pane {
     background-color: #F7F9FD;
     border-radius: 10px;

--- a/themes/docs/html/home.html
+++ b/themes/docs/html/home.html
@@ -23,17 +23,20 @@
 <div class="row">
     <div class="col-lg-7 col-md-7 col-sm-6 instructions">
         <ol>
-            <li>Install <a href="http://leiningen.org/">Leiningen</a></li>
+            <li>Install <a href="https://leiningen.org/">Leiningen</a> or <a href="https://clojure.org/guides/deps_and_cli">Clojure CLI</a> with <a href="https://github.com/seancorfield/clj-new/">clj-new</a></li>
             <li>Create a new cryogen project</li>
             <li>Start the server and visit <code>localhost:3000</code> in your browser</li>
         </ol>
     </div>
     <div class="col-lg-5 col-md-5 col-sm-6">
-        <pre class="shell"><p class="title">Quick Start Guide</p><code class="bash"><span class="dir">~ </span><span
-class="prompt">$ </span><span class="cmd">lein new cryogen my-blog</span>
-<span class="dir">~ </span><span class="prompt">$ </span><span class="cmd">cd my-blog</span>
+        <pre class="shell">
+            <p class="title">Quick Start Guide</p><code class="bash"><span class="dir">~ </span><span
+                class="prompt">$ </span><span class="cmd">lein new cryogen my-blog</span><span class="comment"> # or: </span>
+<span class="dir">~ </span><span
+                    class="prompt">$ </span><span class="cmd">clojure -X:new create :template cryogen :name me.my-blog</span>
+<span class="dir">~ </span><span class="prompt">$ </span><span class="cmd">cd *my-blog</span>
 <span class="dir">~/my-blog </span><span class="prompt">$ </span><span
-class="cmd">lein ring server</span>
+class="cmd">lein serve</span>
 Started server on port 3000</code></pre>
     </div>
 </div>


### PR DESCRIPTION
* Document Clojure CLI as an alternative to Leiningen
* Switch from `lein ring server` to `lein serve` - depends on cryogen-project/cryogen#220
* Clarify configuration wrt. extensibility options
* Update the code to what the latest `lein new` would generate, including whatever is already possible from PR 220