### PR TITLE
Clarified instructions for clj-new as a tool.

### DIFF
--- a/content/md/docs/getting-started.md
+++ b/content/md/docs/getting-started.md
@@ -5,7 +5,12 @@
 
 Cryogen aims to be as simple as possible. There's no need to set up a database or jump through hoops just to get a boilerplate template going.
 
-To get started, you'll need to have either [Leiningen](http://leiningen.org/) or [Clojure CLI](https://clojure.org/guides/deps_and_cli) with [clj-new](https://github.com/seancorfield/clj-new/). Once you have that ready, here's how to get the base template.
+To get started, you'll need to have either
+[Leiningen](http://leiningen.org/) or [Clojure
+CLI](https://clojure.org/guides/deps_and_cli)
+with [clj-new as a
+tool](https://github.com/seancorfield/clj-new#installation-as-a-tool).
+Once you have that ready, here's how to get the base template.
 
 ```
 # Leiningen:
@@ -18,8 +23,8 @@ To get started, you'll need to have either [Leiningen](http://leiningen.org/) or
 # build for deployment
 ~ $ lein run
 
-# Clojure CLI:
-~ $ clojure -X:new :template cryogen :name me.my-blog
+# Clojure CLI (after installing clj-new as a tool - see link above)):
+~ $ clojure -Tclj-new :template cryogen :name me.my-blog
 ~ $ cd me.my-blog
 
 # start continuous build that watches for changes


### PR DESCRIPTION
Small changes to clarify how to first install clj-new as a tool and then set up a cryogen project using clj-new.