### PR TITLE
Correct command to create new project via clj-new

### DIFF
--- a/content/md/docs/getting-started.md
+++ b/content/md/docs/getting-started.md
@@ -24,7 +24,7 @@ Once you have that ready, here's how to get the base template.
 ~ $ lein run
 
 # Clojure CLI (after installing clj-new as a tool - see link above)):
-~ $ clojure -Tclj-new :template cryogen :name me.my-blog
+~ $ clojure -Tclj-new create :template cryogen :name me.my-blog
 ~ $ cd me.my-blog
 
 # start continuous build that watches for changes


### PR DESCRIPTION
I noticed a small omission in the example command for creating new projects using clj-new. This PR fixes that.